### PR TITLE
test/cluster_test: make TestRegionStatistics more stable (tikv#8320)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,7 +254,7 @@ basic-test: install-tools
 
 ci-test-job: install-tools dashboard-ui pd-ut
 	@$(FAILPOINT_ENABLE)
-	./scripts/ci-subtask.sh $(JOB_COUNT) $(JOB_INDEX) || { $(FAILPOINT_DISABLE); exit 1; }
+	./scripts/ci-subtask.sh 4 || { $(FAILPOINT_DISABLE); exit 1; }
 	@$(FAILPOINT_DISABLE)
 
 TSO_INTEGRATION_TEST_PKGS := $(PD_PKG)/tests/server/tso

--- a/scripts/ci-subtask.sh
+++ b/scripts/ci-subtask.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# ./ci-subtask.sh <TOTAL_TASK_N> <TASK_INDEX>
+# ./ci-subtask.sh <TASK_INDEX>
 
 ROOT_PATH_COV=$(pwd)/covprofile
 ROOT_PATH_JUNITFILE=$(pwd)/junitfile

--- a/tests/server/region_syncer/region_syncer_test.go
+++ b/tests/server/region_syncer/region_syncer_test.go
@@ -236,9 +236,10 @@ func TestPrepareChecker(t *testing.T) {
 	re.NoError(err)
 	// waiting for synchronization to complete
 	time.Sleep(3 * time.Second)
+	leaderServer = cluster.GetLeaderServer()
 	err = cluster.ResignLeader()
 	re.NoError(err)
-	re.Equal("pd2", cluster.WaitLeader())
+	re.NotEqual(leaderServer.GetServer().Name(), cluster.WaitLeader())
 	leaderServer = cluster.GetLeaderServer()
 	rc = leaderServer.GetServer().GetRaftCluster()
 	for _, region := range regions {
@@ -284,14 +285,19 @@ func TestPrepareCheckerWithTransferLeader(t *testing.T) {
 	re.NoError(err)
 	// waiting for synchronization to complete
 	time.Sleep(3 * time.Second)
+	leaderServer = cluster.GetLeaderServer()
 	err = cluster.ResignLeader()
 	re.NoError(err)
-	re.Equal("pd2", cluster.WaitLeader())
+	re.NotEqual(leaderServer.GetServer().Name(), cluster.WaitLeader())
+	rc = cluster.GetLeaderServer().GetRaftCluster()
+	re.True(rc.IsPrepared())
 
-	// transfer leader to pd1, can start coordinator immediately.
+	// transfer leader, can start coordinator immediately.
+	leaderServer = cluster.GetLeaderServer()
 	err = cluster.ResignLeader()
 	re.NoError(err)
-	re.Equal("pd1", cluster.WaitLeader())
+	re.NotEqual(leaderServer.GetLeader().GetName(), cluster.WaitLeader())
+	rc = cluster.GetLeaderServer().GetServer().GetRaftCluster()
 	re.True(rc.IsPrepared())
 	re.NoError(failpoint.Disable("github.com/tikv/pd/pkg/schedule/changeCoordinatorTicker"))
 }

--- a/tests/server/region_syncer/region_syncer_test.go
+++ b/tests/server/region_syncer/region_syncer_test.go
@@ -234,6 +234,7 @@ func TestPrepareChecker(t *testing.T) {
 	re.NoError(err)
 	err = pd2.Run()
 	re.NoError(err)
+	re.NotEmpty(cluster.WaitLeader())
 	// waiting for synchronization to complete
 	time.Sleep(3 * time.Second)
 	leaderServer = cluster.GetLeaderServer()
@@ -283,6 +284,7 @@ func TestPrepareCheckerWithTransferLeader(t *testing.T) {
 	re.NoError(err)
 	err = pd2.Run()
 	re.NoError(err)
+	re.NotEmpty(cluster.WaitLeader())
 	// waiting for synchronization to complete
 	time.Sleep(3 * time.Second)
 	leaderServer = cluster.GetLeaderServer()


### PR DESCRIPTION


Signed-off-by: husharp <jinhao.hu@pingcap.com><!--

Thank you for working on PD! Please read PD's [CONTRIBUTING](https://github.com/tikv/pd/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#linking-issues.

-->
Issue Number: Close #xxx

### What is changed and how does it work?

<!--

You could use the "commit message" code block to add more description to the final commit message.
For more info, check https://github.com/tikv/pd/blob/master/CONTRIBUTING.md#format-of-the-commit-message.

-->

```commit-message
```

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of these tests must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Code changes

- Has the configuration change
- Has HTTP API interfaces changed (Don't forget to [add the declarative for the new API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- Has persistent data change

Side effects

- Possible performance regression
- Increased code complexity
- Breaking backward compatibility

Related changes

- PR to update [`pingcap/docs`](https://github.com/pingcap/docs)/[`pingcap/docs-cn`](https://github.com/pingcap/docs-cn):
- PR to update [`pingcap/tiup`](https://github.com/pingcap/tiup):
- Need to cherry-pick to the release branch

### Release note

<!--

A bugfix or a new feature needs a release note. If there is no need to give a release note, just leave it with the `None`.

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

-->

```release-note
None.
```
